### PR TITLE
remove metadata

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -77,30 +77,6 @@
       "help": ""
     },
     {
-      "name": "age",
-      "class": "string",
-      "optional": true,
-      "help": ""
-    },
-    {
-      "name": "tumour_type",
-      "class": "string",
-      "optional": true,
-      "help": ""
-    },
-    {
-      "name": "target_list",
-      "class": "string",
-      "optional": true,
-      "help": ""
-    },
-    {
-      "name": "sex_phenotype",
-      "class": "string",
-      "optional": true,
-      "help": ""
-    },
-    {
       "name": "CTAT_bundle",
       "class": "file",
       "optional": false,

--- a/resources/home/dnanexus/Pan_Cancer_Sample_Report.Rmd
+++ b/resources/home/dnanexus/Pan_Cancer_Sample_Report.Rmd
@@ -11,13 +11,9 @@ params:
   ensbsqlite:
   bam:
   samplename:
-  sexphenotype:
-  targetlist:
   ref_annot:
   mane:
   chimerkb:
-  age:
-  tumourtype:
   cosmic_fusions:
   chimeraviz_limit:
 output:
@@ -56,26 +52,10 @@ fusion_abdriged$X.FusionName <- gsub("--", "::",fusion_abdriged$X.FusionName)
 
 ### 1.1 Sample Meta Data
 ```{r 4-present_metadata}
-# input is fusions comma seperated
-target_list <-  unlist(strsplit(params$targetlist, ","))
-# convert to correct format
-target_list <- gsub("-", "::", target_list)
-# remove any white space
-target_list <- trimws(target_list) 
 predicted_fusions <- unique(fusion_abdriged$X.FusionName)
-TP_fusions <- intersect(target_list, predicted_fusions)
-TP_fusions <- paste0(TP_fusions, collapse = ", ")
-if (length(TP_fusions) == 0){
-  TP_fusions <- NA
-}
 predicted_fusions <- paste0(predicted_fusions, collapse = ", ")
 df <- as.data.frame(rbind(c("Sample_ID", params$samplename),
-                c("Gender", params$sexphenotype),
-                c("Age", params$age ),
-                c("Tumour type", params$tumourtype),
-                c("Target list", params$targetlist),
-                c("Predicted fusions", predicted_fusions),
-                c("True positive fusions", TP_fusions)))
+                c("Predicted fusions", predicted_fusions)))
 
 colnames(df) <- c("Meta data", "Sample Info")
 datatable(df, rownames = F, 

--- a/src/eggd_pancan_report_generator.sh
+++ b/src/eggd_pancan_report_generator.sh
@@ -51,12 +51,9 @@ main() {
     ensbsqlite = '$ensdb_sqlite_name', \
     bam = '${bam_prefix}.nochr.bam', \
     samplename = '$bam_prefix', \
-    sexphenotype = '$sex_phenotype', \
-    targetlist = '$target_list', \
     ref_annot = '$ref_annot_gtf', \
     mane = '$MANE_name', \
     chimerkb='$chimerkb_name', \
-    age = '$age', tumourtype = '$tumour_type', \
     chimeraviz_limit='$chimeraviz_limit', 
     cosmic_fusions='$cosmic_fusions_name'))\"" > cmd.sh
 


### PR DESCRIPTION
Remove the metadata age, tumour_type, target_list and sex_phenotype from the report

Example of job: https://platform.dnanexus.com/projects/GQ0yQk040f92Z2gJk5Y535zq/monitor/job/GbFYxk040f96gP7VzyQpXq79

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_pancan_report_generator/4)
<!-- Reviewable:end -->
