### PR TITLE
PCF-114 change character

### DIFF
--- a/resources/home/dnanexus/Pan_Cancer_Sample_Report.Rmd
+++ b/resources/home/dnanexus/Pan_Cancer_Sample_Report.Rmd
@@ -316,7 +316,7 @@ genes <- unlist(strsplit(fusion_abdriged_annotation$X.FusionName, "::"))
 ```{r 9-chimerkb}
 try({
 chimerkb <- read_excel(params$chimerkb)
-gene_nice <- gsub("--", "-", fusion_abdriged_annotation[,1])
+gene_nice <- gsub("::", "-", fusion_abdriged_annotation[,1])
 chimerkb_sample_fusions <- chimerkb[which(chimerkb$Fusion_pair %in% gene_nice),]
 datatable(chimerkb_sample_fusions, rownames = F,  extensions = c('FixedColumns','Buttons'),
   options = list(

--- a/resources/home/dnanexus/Pan_Cancer_Sample_Report.Rmd
+++ b/resources/home/dnanexus/Pan_Cancer_Sample_Report.Rmd
@@ -361,7 +361,7 @@ try({
     }
   }
   
-  fusion_abdriged_annotation$gene_nice <- gsub("--", "-", fusion_abdriged_annotation[,1])
+  fusion_abdriged_annotation$gene_nice <- gsub("::", "-", fusion_abdriged_annotation[,1])
   filtered_my_df <- my_df[which(my_df$gene_fusion %in% fusion_abdriged_annotation$gene_nice),]
   fusion_abdriged_annotation$gene_fusion_cosmic <- ""
   fusion_abdriged_annotation$gene_fusion_cosmic <- filtered_my_df$links_fusions[match(fusion_abdriged_annotation$gene_nice, filtered_my_df$gene_fusion)]


### PR DESCRIPTION
The chimerkb still assumes we are using the character "--" for the fusions than the "::". Using "--" leads to empty chimerkb table.

Before: https://platform.dnanexus.com/panx/projects/GYxKj504k171KX9QPxp19q49/monitor/job/GfBbG4Q4k17F095GgvQ2v716
After: https://platform.dnanexus.com/panx/projects/GYxKj504k171KX9QPxp19q49/monitor/job/GfBgGjQ4k178KfP8gq01GVPY

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_pancan_report_generator/8)
<!-- Reviewable:end -->
